### PR TITLE
Changed Prometheus Operator deployment, service account, etc identifiers

### DIFF
--- a/metrics/prometheus-operator.yaml
+++ b/metrics/prometheus-operator.yaml
@@ -3,16 +3,16 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: controller
-    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/name: streams-prometheus-operator
     app.kubernetes.io/version: v0.31.1
-  name: prometheus-operator
+  name: streams-prometheus-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: prometheus-operator
+  name: streams-prometheus-operator
 subjects:
 - kind: ServiceAccount
-  name: prometheus-operator
+  name: streams-prometheus-operator
   namespace: myproject
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -20,9 +20,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/component: controller
-    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/name: streams-prometheus-operator
     app.kubernetes.io/version: v0.31.1
-  name: prometheus-operator
+  name: streams-prometheus-operator
 rules:
 - apiGroups:
   - apiextensions.k8s.io
@@ -94,20 +94,20 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/component: controller
-    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/name: streams-prometheus-operator
     app.kubernetes.io/version: v0.31.1
-  name: prometheus-operator
+  name: streams-prometheus-operator
 spec:
   replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/component: controller
-      app.kubernetes.io/name: prometheus-operator
+      app.kubernetes.io/name: streams-prometheus-operator
   template:
     metadata:
       labels:
         app.kubernetes.io/component: controller
-        app.kubernetes.io/name: prometheus-operator
+        app.kubernetes.io/name: streams-prometheus-operator
         app.kubernetes.io/version: v0.31.1
     spec:
       containers:
@@ -117,7 +117,7 @@ spec:
         - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
         - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.31.1
         image: quay.io/coreos/prometheus-operator:v0.31.1
-        name: prometheus-operator
+        name: streams-prometheus-operator
         ports:
         - containerPort: 8080
           name: http
@@ -132,25 +132,25 @@ spec:
           allowPrivilegeEscalation: false
       nodeSelector:
         beta.kubernetes.io/os: linux
-      serviceAccountName: prometheus-operator
+      serviceAccountName: streams-prometheus-operator
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/component: controller
-    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/name: streams-prometheus-operator
     app.kubernetes.io/version: v0.31.1
-  name: prometheus-operator
+  name: streams-prometheus-operator
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: controller
-    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/name: streams-prometheus-operator
     app.kubernetes.io/version: v0.31.1
-  name: prometheus-operator
+  name: streams-prometheus-operator
 spec:
   clusterIP: None
   ports:
@@ -159,4 +159,4 @@ spec:
     targetPort: http
   selector:
     app.kubernetes.io/component: controller
-    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/name: streams-prometheus-operator


### PR DESCRIPTION
The OCP 4.1 cluster (using OCP 4.1.13 installed for AWS), already provides a Prometheus Operator instance which already has cluster role, role binding and so on with exactly the same name as our provided Prometheus Operator YAML file for this demo.
It means that they are going to clash.
The best way should be deploying the Prometheus Operator not using our provided YAML file but the Operator Hub but the current build has Prometheus 0.27 with the following problem https://bugzilla.redhat.com/show_bug.cgi?id=1735691 so no Prometheus server can be deployed.
Waiting for a new OCP 4.1 build including the above fixes, this PR changes the identifiers of service accoung, cluster role, etc etc of our Prometheus Operator YAML provided to avoid it clashing with the cluster monitoring operator.