### PR TITLE
Set specific InfluxDB datasource not relying on default

### DIFF
--- a/metrics/grafana/kafka-iot-dashboard.json
+++ b/metrics/grafana/kafka-iot-dashboard.json
@@ -20,6 +20,7 @@
         "links": [],
         "panels": [
             {
+                "datasource": "InfluxDB",
                 "gridPos": {
                     "h": 8,
                     "w": 12,
@@ -99,6 +100,7 @@
                 "type": "gauge"
             },
             {
+                "datasource": "InfluxDB",
                 "gridPos": {
                     "h": 8,
                     "w": 12,
@@ -178,6 +180,7 @@
                 "type": "gauge"
             },
             {
+                "datasource": "InfluxDB",
                 "aliasColors": {
                     "device-data.mean": "yellow"
                 },
@@ -299,6 +302,7 @@
                 }
             },
             {
+                "datasource": "InfluxDB",
                 "aliasColors": {},
                 "bars": false,
                 "dashLength": 10,


### PR DESCRIPTION
Up to now, the Kafka IoT dashboard was using the "default" datasource which luckily was set as the InfluxDB one by Grafana. We were lucky on that. I had a deployment were Prometheus was set as default and of course, this IoT dashboard wasn't working anymore.
This PR set explicitely what is the datasource for the Kafka IoT dashboard.